### PR TITLE
feat: Enable multi-sheet support for excel2json and json2excel tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The built-in `Doc Extractor` would convert input `.xlsx` file to markdown table 
 
 - The output is placed in the `text` output field rather than the `json` field in order to preserving the header order.
 - All cells are parsed as **string**, no matter what it is.
+- If the uploaded Excel file contains multiple sheets, the plugin will automatically convert it into a JSON object, where each key is the sheet name and the value is the data array of the corresponding sheet.
 
 | Name | Age | Date |
 |------|-----|------|
@@ -40,6 +41,7 @@ The built-in `Doc Extractor` would convert input `.xlsx` file to markdown table 
 ### json → xlsx
 
 - The output filename can be configured, default `Converted_Data`
+- If the input JSON is an object (whose values are arrays), the plugin will automatically create a multi-sheet Excel file, where each key of the object will become a sheet name.
 
 ![](_assets/workflow_run.png)
 ![](_assets/output_xlsx.png)

--- a/tools/excel2json.py
+++ b/tools/excel2json.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import Generator
 from typing import Any
 
@@ -10,8 +11,23 @@ class Excel2JsonTool(Tool):
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
         file_meta = tool_parameters['file']
         try:
-            df = pd.read_excel(file_meta.url, dtype=str)
-        except Exception as e:
-            raise Exception(f"Error reading Excel file: {str(e)}")
+            xls = pd.ExcelFile(file_meta.url)
+            sheet_names = xls.sheet_names
 
-        yield self.create_text_message(df.to_json(orient="records", force_ascii=False))
+            if len(sheet_names) > 1:
+                # Multiple sheets
+                all_sheets_data = pd.read_excel(file_meta.url, sheet_name=None, dtype=str)
+                json_output = {}
+                for sheet_name, df in all_sheets_data.items():
+                    # Convert DataFrame to a list of records (dicts)
+                    json_output[sheet_name] = json.loads(df.to_json(orient="records", force_ascii=False))
+                
+                # Convert the entire structure to a JSON string
+                yield self.create_text_message(json.dumps(json_output, ensure_ascii=False, indent=2))
+            else:
+                # Single sheet
+                df = pd.read_excel(file_meta.url, dtype=str)
+                yield self.create_text_message(df.to_json(orient="records", force_ascii=False))
+
+        except Exception as e:
+            raise Exception(f"Error processing Excel file: {str(e)}")


### PR DESCRIPTION
### Description

This PR introduces support for handling Excel files with multiple sheets. The `excel2json` tool can now convert all sheets into a structured JSON object, and the `json2excel` tool can generate an Excel file with multiple sheets from that JSON structure. This enhances the plugin's capability to manage complex Excel data.

### Changes

*   **excel2json**: Updated the tool to read all sheets from an Excel file. It now outputs a JSON object where keys are sheet names and values are the corresponding sheet data (as an array of objects).
*   **json2excel**: Updated the tool to accept a JSON object with sheet names as keys. It creates a new sheet in the output Excel file for each key-value pair.
*   **README.md**: Updated the documentation to reflect the new multi-sheet JSON structure and provide clear usage examples.

### How to Test

1.  **excel2json**:
    *   Upload an Excel file that contains multiple sheets.
    *   Run the tool and verify that the output JSON correctly represents all sheets, with sheet names serving as the keys.

2.  **json2excel**:
    *   Provide a JSON input structured with sheet names as keys (e.g., `{"Orders": [...], "Customers": [...]}`).
    *   Run the tool and check if the generated `.xlsx` file contains separate sheets named "Orders" and "Customers" with the correct data.
