### PR TITLE
feat: add [format] metadata support for row/column sizing in json2excel

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Author:** qiangxinglin
 
-**Version:** 0.0.3
+**Version:** 0.0.5
 
 **Type:** tool
 
@@ -46,12 +46,126 @@ The built-in `Doc Extractor` would convert input `.xlsx` file to markdown table 
 ![](_assets/workflow_run.png)
 ![](_assets/output_xlsx.png)
 
+#### Format Settings
+
+The plugin supports optional formatting for row heights and column widths using the `[format]` reserved key.
+
+> **Note:** Excel prohibits sheet names containing these characters: `/ \ ? * : [ ]`
+> Therefore, `[format]` is guaranteed to never conflict with actual sheet names.
+
+##### `[format]` Structure
+
+```json
+{
+  "[format]": {
+    "defaults": {
+      "rowHeight": 20,           // Default height for all rows
+      "columnWidth": 15,         // Default width for all columns
+      "rowHeights": {            // Specific row heights (1-based)
+        "1": 30,                 // Row 1 height = 30
+        "2": 25                  // Row 2 height = 25
+      },
+      "columnWidths": {          // Specific column widths
+        "A": 25,                 // Column A width = 25
+        "B": 15                  // Column B width = 15
+      }
+    },
+    "sheets": {
+      "SheetName": {             // Per-sheet overrides
+        "rowHeight": 22,
+        "columnWidth": 18,
+        "rowHeights": {"1": 28},
+        "columnWidths": {"A": 30, "B": 20}
+      }
+    }
+  },
+  "SheetName": [...]             // Actual data
+}
+```
+
+##### Format Priority Rules
+
+Settings are applied in the following order (later overrides earlier):
+
+1. `[format].defaults.rowHeight` / `columnWidth` - Global defaults for all rows/columns
+2. `[format].sheets.<name>.rowHeight` / `columnWidth` - Per-sheet defaults
+3. `[format].defaults.rowHeights` / `columnWidths` - Global specific rows/columns
+4. `[format].sheets.<name>.rowHeights` / `columnWidths` - Per-sheet specific rows/columns
+
+##### Validation and Warnings
+
+- **Unknown sheet references**: If `[format].sheets` references a sheet that doesn't exist in the data, a warning will be displayed and those configurations will be ignored. The Excel file will still be generated successfully.
+- **Type errors**: If format values have incorrect types (e.g., non-dict, negative numbers), an error will be thrown and the Excel generation will fail.
+
+##### Examples
+
+**Single sheet with global formatting:**
+
+```json
+{
+  "[format]": {
+    "defaults": {
+      "rowHeight": 20,
+      "columnWidth": 15
+    }
+  },
+  "Sheet1": [
+    {"Name": "John", "Age": "18"},
+    {"Name": "Doe", "Age": "20"}
+  ]
+}
+```
+
+**Multiple sheets with per-sheet formatting:**
+
+```json
+{
+  "[format]": {
+    "defaults": {
+      "rowHeight": 18
+    },
+    "sheets": {
+      "Employees": {
+        "columnWidths": {"A": 25, "B": 15},
+        "rowHeights": {"1": 30}
+      },
+      "Departments": {
+        "columnWidths": {"A": 20}
+      }
+    }
+  },
+  "Employees": [{"Name": "John", "Department": "R&D"}],
+  "Departments": [{"ID": "1", "Name": "HR"}]
+}
+```
+
+**Column identifiers:**
+
+You can use either Excel letters or 1-based numeric indexes:
+
+```json
+{
+  "[format]": {
+    "defaults": {
+      "columnWidths": {
+        "A": 25,    // Letter format
+        "1": 25,    // Numeric format (same as "A")
+        "B": 15,
+        "2": 15     // Same as "B"
+      }
+    }
+  },
+  "Sheet1": [...]
+}
+```
+
 
 ## Used Open sourced projects
 
 - [pandas](https://github.com/pandas-dev/pandas), BSD 3-Clause License
 
 ## Changelog
+- **0.0.5**: Add `[format]` metadata support for controlling row heights and column widths during JSON → Excel conversion
 - **0.0.4**: Add missing dependency (xlrd)
 - **0.0.3**: Add multi-sheet support for Excel processing (closes #13)
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.0.4
+version: 0.0.5
 type: plugin
 author: qiangxinglin
 name: excel_tools

--- a/tools/json2excel.py
+++ b/tools/json2excel.py
@@ -7,50 +7,328 @@ from dify_plugin.entities.tool import ToolInvokeMessage
 
 import pandas as pd
 from io import BytesIO
+from openpyxl.utils import get_column_letter
+from openpyxl.styles import Alignment
+
 
 class Json2ExcelTool(Tool):
+    """
+    Convert JSON to Excel with optional formatting support.
+
+    Supports the [format] reserved key for row heights and column widths.
+    Excel prohibits sheet names containing [ ] characters, so [format] is safe.
+    """
+
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
         json_str = tool_parameters['json_str']
-        
-        try:
-            data = json.loads(json_str)
-        except json.JSONDecodeError as e:
-            raise Exception(f"Invalid JSON format: {e}")
 
+        # Parse JSON and extract sheets data and format configuration
+        payload = self._load_json(json_str)
+        sheets_data, format_cfg = self._extract_sheets_and_format(payload)
+        defaults, sheet_formats, warnings = self._prepare_format_sections(format_cfg, sheets_data.keys())
+
+        # Create Excel file
         excel_buffer = BytesIO()
         try:
             with pd.ExcelWriter(excel_buffer, engine='openpyxl') as writer:
-                if isinstance(data, dict):
-                    # If the top level is an object, treat keys as sheet names
-                    for sheet_name, records in data.items():
-                        if not isinstance(records, list):
-                            raise Exception(f"Value for sheet '{sheet_name}' must be a list of records.")
-                        df = pd.DataFrame(records)
-                        df.to_excel(writer, sheet_name=sheet_name, index=False)
-                elif isinstance(data, list):
-                    # If the top level is an array, write to a single sheet
-                    df = pd.DataFrame(data)
-                    df.to_excel(writer, sheet_name='Sheet1', index=False)
-                else:
-                    raise Exception("JSON must be an object (for multiple sheets) or an array (for a single sheet).")
+                for sheet_name, records in sheets_data.items():
+                    if not isinstance(records, list):
+                        raise Exception(f"Value for sheet '{sheet_name}' must be a list of records.")
+
+                    # Write data to sheet
+                    df = pd.DataFrame(records)
+                    df.to_excel(writer, sheet_name=sheet_name, index=False)
+
+                    # Apply formatting if configured
+                    worksheet = writer.sheets[sheet_name]
+                    self._apply_formatting(
+                        worksheet=worksheet,
+                        sheet_name=sheet_name,
+                        defaults=defaults,
+                        sheet_format=sheet_formats.get(sheet_name, {})
+                    )
         except Exception as e:
             raise Exception(f"Error converting data to Excel: {str(e)}")
 
-        # create a blob with the excel bytes
+        # Create blob message with the Excel bytes
         try:
             excel_buffer.seek(0)
             excel_bytes = excel_buffer.getvalue()
             filename = tool_parameters.get('filename', 'Converted Data')
             filename = f"{filename.replace(' ', '_')}.xlsx"
 
+            # Output warnings if any
+            if warnings:
+                yield self.create_text_message(f"⚠️ Warning: {warnings}")
+
             yield self.create_text_message(f"Excel file '{filename}' generated successfully")
 
             yield self.create_blob_message(
-                    blob=excel_bytes,
-                    meta={
-                        "mime_type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                        "filename": filename
-                    }
-                )
+                blob=excel_bytes,
+                meta={
+                    "mime_type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    "filename": filename
+                }
+            )
         except Exception as e:
             raise Exception(f"Error creating Excel file message: {str(e)}")
+
+    def _load_json(self, json_str: str) -> Any:
+        """Parse JSON string and return the payload."""
+        try:
+            return json.loads(json_str)
+        except json.JSONDecodeError as exc:
+            raise Exception(f"Invalid JSON format: {exc}")
+
+    def _extract_sheets_and_format(self, payload: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+        """
+        Extract sheets data and format configuration from payload.
+
+        Returns:
+            (sheets_data, format_cfg) where:
+            - sheets_data: dict mapping sheet names to record lists
+            - format_cfg: dict containing format configuration
+        """
+        if isinstance(payload, list):
+            # Single sheet without formatting
+            return {"Sheet1": payload}, {}
+
+        if isinstance(payload, dict):
+            # Extract format configuration
+            # Check if [format] key exists and validate its type
+            if "[format]" in payload:
+                format_cfg = payload["[format]"]
+                if not isinstance(format_cfg, dict):
+                    raise Exception("The '[format]' section must be an object when provided.")
+            else:
+                format_cfg = {}
+
+            # Extract sheets data (all keys except [format])
+            sheets = {k: v for k, v in payload.items() if k != "[format]"}
+            if not sheets:
+                raise Exception("At least one sheet must be provided alongside the '[format]' block.")
+
+            return sheets, format_cfg
+
+        raise Exception("JSON must be an array (single sheet) or object (multiple sheets).")
+
+    def _prepare_format_sections(
+        self,
+        format_cfg: dict[str, Any],
+        sheet_names: set[str]
+    ) -> tuple[dict[str, Any], dict[str, Any], str]:
+        """
+        Validate and prepare format configuration sections.
+
+        Returns:
+            (defaults, sheet_formats, warnings) where:
+            - defaults: global default formatting
+            - sheet_formats: per-sheet formatting overrides
+            - warnings: warning message if any (empty string if no warnings)
+        """
+        if not format_cfg:
+            return {}, {}, ""
+
+        # Extract and normalize defaults and sheet_formats
+        defaults = format_cfg.get("defaults")
+        sheet_formats = format_cfg.get("sheets")
+
+        # Validate types and normalize falsy values to empty dicts
+        if "defaults" in format_cfg:
+            if defaults is None:
+                defaults = {}
+            elif not isinstance(defaults, dict):
+                raise Exception("The '[format].defaults' section must be an object.")
+        else:
+            defaults = {}
+
+        if "sheets" in format_cfg:
+            if sheet_formats is None:
+                sheet_formats = {}
+            elif not isinstance(sheet_formats, dict):
+                raise Exception("The '[format].sheets' section must be an object.")
+        else:
+            sheet_formats = {}
+
+        # Check for unknown sheet references (warning mode)
+        unknown = set(sheet_formats.keys()) - set(sheet_names)
+        warning_msg = ""
+        if unknown:
+            missing = ", ".join(sorted(unknown))
+            warning_msg = f"The '[format].sheets' section references unknown sheets: {missing}. These configurations were ignored."
+            # Remove unknown sheets from sheet_formats
+            for unknown_sheet in unknown:
+                del sheet_formats[unknown_sheet]
+
+        # Validate each sheet format is an object
+        for sheet_name, cfg in sheet_formats.items():
+            if cfg is None:
+                sheet_formats[sheet_name] = {}
+            elif not isinstance(cfg, dict):
+                raise Exception(f"The '[format].sheets.{sheet_name}' section must be an object.")
+
+        return defaults, sheet_formats, warning_msg
+
+    def _apply_formatting(
+        self,
+        worksheet,
+        sheet_name: str,
+        defaults: dict[str, Any],
+        sheet_format: dict[str, Any]
+    ) -> None:
+        """
+        Apply formatting to worksheet following priority rules:
+        1. defaults.rowHeight/columnWidth (global defaults)
+        2. sheets.<name>.rowHeight/columnWidth (sheet defaults)
+        3. defaults.rowHeights/columnWidths (global specific rows/columns)
+        4. sheets.<name>.rowHeights/columnWidths (sheet specific rows/columns)
+        """
+        max_row = max(worksheet.max_row, 1)
+        max_col = max(worksheet.max_column, 1)
+
+        # Apply vertical center alignment to all cells by default
+        for row in worksheet.iter_rows(min_row=1, max_row=max_row, min_col=1, max_col=max_col):
+            for cell in row:
+                cell.alignment = Alignment(vertical='center')
+
+        # Apply uniform row heights (priority 1 & 2)
+        self._apply_uniform_row_height(
+            worksheet, max_row, defaults.get("rowHeight"), "defaults.rowHeight"
+        )
+        self._apply_uniform_row_height(
+            worksheet, max_row, sheet_format.get("rowHeight"), f"sheets.{sheet_name}.rowHeight"
+        )
+
+        # Apply uniform column widths (priority 1 & 2)
+        self._apply_uniform_column_width(
+            worksheet, max_col, defaults.get("columnWidth"), "defaults.columnWidth"
+        )
+        self._apply_uniform_column_width(
+            worksheet, max_col, sheet_format.get("columnWidth"), f"sheets.{sheet_name}.columnWidth"
+        )
+
+        # Apply specific row heights (priority 3 & 4)
+        self._apply_row_map(
+            worksheet, defaults.get("rowHeights"), "defaults.rowHeights"
+        )
+        self._apply_row_map(
+            worksheet, sheet_format.get("rowHeights"), f"sheets.{sheet_name}.rowHeights"
+        )
+
+        # Apply specific column widths (priority 3 & 4)
+        self._apply_column_map(
+            worksheet, defaults.get("columnWidths"), "defaults.columnWidths"
+        )
+        self._apply_column_map(
+            worksheet, sheet_format.get("columnWidths"), f"sheets.{sheet_name}.columnWidths"
+        )
+
+    def _apply_uniform_row_height(self, worksheet, row_count: int, value: Any, label: str) -> None:
+        """Apply the same height to all rows."""
+        height = self._coerce_positive_number(value, label)
+        if height is None:
+            return
+        for row in range(1, row_count + 1):
+            worksheet.row_dimensions[row].height = height
+
+    def _apply_uniform_column_width(self, worksheet, column_count: int, value: Any, label: str) -> None:
+        """Apply the same width to all columns."""
+        width = self._coerce_positive_number(value, label)
+        if width is None:
+            return
+        for col_idx in range(1, column_count + 1):
+            col_letter = get_column_letter(col_idx)
+            worksheet.column_dimensions[col_letter].width = width
+
+    def _apply_row_map(self, worksheet, mapping: Any, label: str) -> None:
+        """Apply specific heights to individual rows."""
+        if mapping is None:
+            return
+        if not isinstance(mapping, dict):
+            raise Exception(f"The '{label}' section must be an object.")
+
+        for raw_row, raw_height in mapping.items():
+            row_index = self._parse_row_identifier(raw_row, label)
+            height = self._coerce_positive_number(raw_height, f"{label}[{raw_row}]")
+            worksheet.row_dimensions[row_index].height = height
+
+    def _apply_column_map(self, worksheet, mapping: Any, label: str) -> None:
+        """Apply specific widths to individual columns."""
+        if mapping is None:
+            return
+        if not isinstance(mapping, dict):
+            raise Exception(f"The '{label}' section must be an object.")
+
+        for raw_col, raw_width in mapping.items():
+            column_letter = self._parse_column_identifier(raw_col, label)
+            width = self._coerce_positive_number(raw_width, f"{label}[{raw_col}]")
+            worksheet.column_dimensions[column_letter].width = width
+
+    def _parse_row_identifier(self, raw_value: Any, label: str) -> int:
+        """
+        Parse row identifier to 1-based integer.
+
+        Accepts: "1", "2", 1, 2, etc.
+        """
+        try:
+            row = int(str(raw_value))
+        except (TypeError, ValueError):
+            raise Exception(f"Row identifiers in '{label}' must be positive integers.")
+
+        if row <= 0:
+            raise Exception(f"Row identifiers in '{label}' must be 1-based positive integers.")
+
+        return row
+
+    def _parse_column_identifier(self, raw_value: Any, label: str) -> str:
+        """
+        Parse column identifier to Excel letter format.
+
+        Accepts:
+        - Letters: "A", "B", "AA", "AB", etc.
+        - 1-based integers: 1, 2, "1", "2", etc.
+
+        Returns: Excel column letter (e.g., "A", "B", "AA")
+        """
+        if isinstance(raw_value, int):
+            index = raw_value
+        elif isinstance(raw_value, str):
+            token = raw_value.strip()
+            if not token:
+                raise Exception(f"Column identifiers in '{label}' cannot be empty.")
+
+            if token.isdigit():
+                # Numeric string like "1", "2"
+                index = int(token)
+            elif token.isalpha():
+                # Letter string like "A", "B", "AA"
+                return token.upper()
+            else:
+                raise Exception(f"Column identifiers in '{label}' must be letters or integers.")
+        else:
+            raise Exception(f"Column identifiers in '{label}' must be letters or integers.")
+
+        # Convert 1-based index to Excel letter
+        if index <= 0:
+            raise Exception(f"Column identifiers in '{label}' must be 1-based positive integers.")
+
+        return get_column_letter(index)
+
+    def _coerce_positive_number(self, value: Any, label: str) -> float | None:
+        """
+        Coerce value to a positive number.
+
+        Returns None if value is None, otherwise validates and returns float.
+        """
+        if value is None:
+            return None
+
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            raise Exception(f"The value for '{label}' must be a positive number.")
+
+        if number <= 0:
+            raise Exception(f"The value for '{label}' must be greater than zero.")
+
+        return number


### PR DESCRIPTION
## Summary

Add formatting support for Excel generation using the `[format]` reserved key. Users can now control row heights and column widths at both global and per-sheet levels.

## Features

### Core Functionality
- **`[format]` reserved key**: Leverages Excel's sheet naming restrictions (`[]` characters are forbidden) to safely reserve this key
- **Row height control**: Set default heights for all rows or specific rows
- **Column width control**: Set default widths for all columns or specific columns
- **4-level priority system**:
  1. Global defaults (`[format].defaults.rowHeight/columnWidth`)
  2. Sheet-level defaults (`[format].sheets.<name>.rowHeight/columnWidth`)
  3. Global specific rows/columns (`[format].defaults.rowHeights/columnWidths`)
  4. Sheet-specific rows/columns (`[format].sheets.<name>.rowHeights/columnWidths`)

### Flexibility
- **Column identifiers**: Support both Excel letters (`"A"`, `"B"`, `"AA"`) and 1-based numeric indexes (`1`, `2`, `"1"`, `"2"`)
- **Row identifiers**: 1-based integers (matching Excel's row numbering)

### Validation & Error Handling
- **Warning mode for unknown sheets**: If `[format].sheets` references non-existent sheets, display warning and continue (LLM-friendly)
- **Type validation**: Ensure all format sections are objects
- **Value validation**: Ensure heights/widths are positive numbers
- **Clear error messages**: Provide actionable feedback for misconfigurations

## Usage Examples

### Single sheet with formatting
```json
{
  "[format]": {
    "defaults": {
      "rowHeight": 20,
      "columnWidth": 15
    }
  },
  "Sheet1": [
    {"Name": "John", "Age": "18"},
    {"Name": "Doe", "Age": "20"}
  ]
}
```

### Multiple sheets with per-sheet formatting
```json
{
  "[format]": {
    "defaults": {"rowHeight": 18},
    "sheets": {
      "Employees": {
        "columnWidths": {"A": 25, "B": 15},
        "rowHeights": {"1": 30}
      }
    }
  },
  "Employees": [{"Name": "John", "Department": "R&D"}],
  "Departments": [{"ID": "1", "Name": "HR"}]
}
```

### Warning mode example
```json
{
  "[format]": {
    "sheets": {
      "Employees": {"columnWidths": {"A": 25}},
      "NonExistentSheet": {"rowHeight": 20}
    }
  },
  "Employees": [{"Name": "John"}]
}
```

**Output:**
```
⚠️ Warning: The '[format].sheets' section references unknown sheets: NonExistentSheet. These configurations were ignored.
Excel file 'Converted_Data.xlsx' generated successfully
```

## Backward Compatibility

**Fully backward compatible** - all existing JSON formats continue to work:

Single sheet without formatting:
```json
[{"Name": "John", "Age": "18"}]
```

Multiple sheets without formatting:
```json
{
  "Employees": [{"Name": "John"}],
  "Departments": [{"ID": "1"}]
}
```

## Documentation

- Added "Format Settings" section in README

## Design Decisions

### Why using `[format]` as the key?

**Rationale:**
- Excel prohibits sheet names containing `[]` characters
- This is a native Excel constraint, not an artificial restriction
- Guarantees zero collision risk with actual sheet names
- More aligned with Excel's own rules

### Why Warning Mode for Unknown Sheets?

**Rationale:**
- **LLM-friendly**: In Dify workflows, LLMs may generate imperfect JSON with typos or outdated sheet names
- **User-friendly**: Minor configuration errors shouldn't block the entire workflow
- **Transparent**: Users still see warnings and know what was ignored
- **Fail-fast for critical errors**: Type errors and invalid values still throw errors

### Why 4-Level Priority System?

**Rationale:**
- **Flexibility**: Allows both global defaults and fine-grained control
- **Intuitive**: Follows CSS-like specificity rules (more specific overrides less specific)
- **Extensible**: Easy to add more levels in the future if needed

**Priority order:**
1. Global defaults (least specific)
2. Sheet-level defaults
3. Global specific rows/columns
4. Sheet-specific rows/columns (most specific)
